### PR TITLE
Display access address on readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 한국의 문화재 정보를 체계적으로 관리하고 다국어로 제공하는 웹 기반 디지털 아카이브 시스템입니다.
 
+## 🌐 접속 주소
+
+### 로컬 개발 환경
+```bash
+# 로컬 서버 실행
+python -m http.server 8080 --bind 0.0.0.0
+
+# 브라우저에서 접속
+http://localhost:8080
+```
+
+### 배포 환경
+- **GitHub Pages**: `https://USERNAME.github.io/korean-heritage-wiki`
+- **Netlify**: `https://your-site-name.netlify.app`
+- **Vercel**: `https://your-project.vercel.app`
+- **Firebase Hosting**: `https://your-project.web.app`
+
+### 직접 파일 접속
+- **메인 페이지**: `index.html` (자동으로 `main.html`로 리다이렉트)
+- **애플리케이션**: `main.html`
+
 ## 🌟 주요 기능
 
 ### 📊 대시보드 및 통계


### PR DESCRIPTION
Add an 'Access Address' section to `README.md` to clearly inform users how to access the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d76d9c4-63c9-4586-bfbc-200de55eaa2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d76d9c4-63c9-4586-bfbc-200de55eaa2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

