### PR TITLE
Fix kakao maps api script loading order

### DIFF
--- a/main.html
+++ b/main.html
@@ -8,6 +8,9 @@
     <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&family=Noto+Serif+KR:wght@400;500;700&family=Inter:wght@400;500;600&family=Crimson+Text:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
+    
+    <!-- Kakao Maps API -->
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f3b94f450409b9b743b3932047bdbe4b"></script>
 </head>
 <body>
     <!-- 사이드바 네비게이션 -->
@@ -786,11 +789,6 @@
     <!-- CSV 파서 -->
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     
-    <!-- Kakao Maps API -->
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f3b94f450409b9b743b3932047bdbe4b"></script>
-    
-
-
     <!-- 문화재 데이터 (CSV 대신 JavaScript) -->
     <script src="js/heritage-data.js"></script>
     


### PR DESCRIPTION
Move Kakao Maps API script to the `<head>` section to resolve "Kakao Maps API not loaded" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee221155-bc1f-49b8-bf24-dc99b36fc111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee221155-bc1f-49b8-bf24-dc99b36fc111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

