### PR TITLE
Fix heritage detail link to dynamic URL

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -835,7 +835,7 @@ async function renderHeritageDetail(item) {
     const linksContainer = document.getElementById('heritage-links');
     if (linksContainer) {
         linksContainer.innerHTML = `
-            <a href="https://www.heritage.go.kr" target="_blank" class="heritage-link d-block mb-2">
+            <a href="${item.source_url || 'https://www.heritage.go.kr'}" target="_blank" class="heritage-link d-block mb-2">
                 <i class="fas fa-external-link-alt me-2"></i>문화재청 홈페이지
             </a>
             ${item.source_url ? `


### PR DESCRIPTION
Make the external link in the heritage detail view dynamic to point to specific item pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab7a37d8-1b2e-4af4-87ea-88c7e6c4d196">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab7a37d8-1b2e-4af4-87ea-88c7e6c4d196">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

