### PR TITLE
Debug heritage_data.js language toggle

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -348,7 +348,7 @@ function renderGridView(items) {
         const eraInfo = getEraInformation(item);
         return `
         <div class="heritage-grid-item">
-            <div class="card heritage-card h-100" onclick="viewHeritageDetail('${item.name}')">
+            <div class="card heritage-card h-100" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
                 <div class="card-img-top heritage-image">
                     ${item.image_url ? 
                         `<img src="${item.image_url}" alt="${item.name}" onerror="this.style.display='none'; this.parentElement.classList.add('no-image')">` : 
@@ -361,7 +361,7 @@ function renderGridView(items) {
                         <small class="text-muted">${item.location}</small>
                     </div>
                     <h6 class="card-title">${dataManager.currentLanguage === 'ko' ? item.name : (item.name_en || item.name)}</h6>
-                    <p class="card-text text-truncate-2">
+                    <p class="card-text text-truncate-2 heritage-description">
                         ${dataManager.currentLanguage === 'ko' 
                             ? (item.content ? item.content.substring(0, 100) + '...' : '설명 없음')
                             : (item.content_en ? item.content_en.substring(0, 100) + '...' : '영문 설명 준비 중...')
@@ -388,7 +388,7 @@ function renderListView(items) {
     tbody.innerHTML = items.map(item => {
         const eraInfo = getEraInformation(item);
         return `
-        <tr class="heritage-list-row" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
+        <tr class="heritage-list-row" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
             <td>
                 <div class="heritage-list-image">
                     ${item.image_url ? 
@@ -412,7 +412,7 @@ function renderListView(items) {
                 ${eraInfo ? `<br><small class="text-muted">${eraInfo}</small>` : ''}
             </td>
             <td>
-                <div class="heritage-list-desc">
+                <div class="heritage-list-desc heritage-description">
                     ${dataManager.currentLanguage === 'ko' 
                         ? (item.content ? item.content.substring(0, 150) + '...' : '설명 없음')
                         : (item.content_en ? item.content_en.substring(0, 150) + '...' : '영문 설명 준비 중...')
@@ -666,6 +666,9 @@ function getEraInformation(item) {
  */
 async function renderHeritageDetail(item) {
     console.log('상세 페이지 렌더링 시작:', item.name);
+    
+    // 현재 상세 아이템 설정 (언어 토글용)
+    dataManager.currentDetailItem = item;
     
     // 시대 정보 가져오기
     const eraInfo = getEraInformation(item);
@@ -1077,7 +1080,7 @@ function renderCategoryGridView(items) {
         const eraInfo = getEraInformation(item);
         return `
         <div class="heritage-grid-item">
-            <div class="card heritage-card h-100" onclick="viewHeritageDetail('${item.name}')">
+            <div class="card heritage-card h-100" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
                 <div class="card-img-top heritage-image">
                     ${item.image_url ? 
                         `<img src="${item.image_url}" alt="${item.name}" onerror="this.style.display='none'; this.parentElement.classList.add('no-image')">` : 
@@ -1090,7 +1093,7 @@ function renderCategoryGridView(items) {
                         <small class="text-muted">${item.location || '지역 정보 없음'}</small>
                     </div>
                     <h6 class="card-title">${dataManager.currentLanguage === 'ko' ? item.name : (item.name_en || item.name)}</h6>
-                    <p class="card-text text-truncate-2">
+                    <p class="card-text text-truncate-2 heritage-description">
                         ${dataManager.currentLanguage === 'ko' 
                             ? (item.content ? item.content.substring(0, 100) + '...' : '설명 없음')
                             : (item.content_en ? item.content_en.substring(0, 100) + '...' : '영문 설명 준비 중...')
@@ -1130,7 +1133,7 @@ function renderCategoryListView(items) {
     tbody.innerHTML = items.map(item => {
         const eraInfo = getEraInformation(item);
         return `
-        <tr class="heritage-list-row" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
+        <tr class="heritage-list-row" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
             <td>
                 <div class="heritage-list-image">
                     ${item.image_url ? 
@@ -1151,7 +1154,7 @@ function renderCategoryListView(items) {
                 <span class="text-muted">${item.location || '정보 없음'}</span>
             </td>
             <td>
-                <div class="heritage-list-desc">
+                <div class="heritage-list-desc heritage-description">
                     ${dataManager.currentLanguage === 'ko' 
                         ? (item.content ? item.content.substring(0, 150) + '...' : '설명 없음')
                         : (item.content_en ? item.content_en.substring(0, 150) + '...' : '영문 설명 준비 중...')

--- a/js/data-manager.js
+++ b/js/data-manager.js
@@ -9,6 +9,7 @@ class DataManager {
         this.locations = new Set();
         this.isLoaded = false;
         this.currentLanguage = 'ko';
+        this.currentDetailItem = null;
         
         this.setupLanguageToggle();
     }
@@ -1668,11 +1669,62 @@ class DataManager {
     }
     
     updateDetailLanguage() {
-        // 상세 페이지 언어 업데이트 (추후 구현)
+        const currentItem = this.currentDetailItem;
+        if (!currentItem) return;
+        
+        const descriptionElement = document.getElementById('heritage-description');
+        if (!descriptionElement) return;
+        
+        // 현재 선택된 언어 확인
+        const isKorean = this.currentLanguage === 'ko';
+        
+        if (isKorean) {
+            // 한글 설명 표시
+            descriptionElement.innerHTML = this.formatDescription(currentItem.content || '설명이 없습니다.');
+        } else {
+            // 영어 설명 표시
+            const englishContent = currentItem.content_en || this.generateEnglishDescription(currentItem);
+            descriptionElement.innerHTML = this.formatDescription(englishContent);
+        }
     }
     
     updateListLanguage() {
-        // 목록 페이지 언어 업데이트 (추후 구현)
+        // 현재 표시된 문화재 목록의 설명을 언어에 맞게 업데이트
+        const isKorean = this.currentLanguage === 'ko';
+        
+        // 그리드 뷰 업데이트
+        const gridItems = document.querySelectorAll('#heritage-grid .heritage-card');
+        gridItems.forEach(card => {
+            const descriptionElement = card.querySelector('.heritage-description');
+            if (descriptionElement) {
+                const itemId = card.dataset.itemId;
+                const item = this.heritageData.find(h => h.id === itemId);
+                if (item) {
+                    if (isKorean) {
+                        descriptionElement.textContent = item.content || '설명이 없습니다.';
+                    } else {
+                        descriptionElement.textContent = item.content_en || this.generateEnglishDescription(item);
+                    }
+                }
+            }
+        });
+        
+        // 리스트 뷰 업데이트
+        const listItems = document.querySelectorAll('#heritage-list-tbody tr');
+        listItems.forEach(row => {
+            const descriptionCell = row.querySelector('.heritage-description');
+            if (descriptionCell) {
+                const itemId = row.dataset.itemId;
+                const item = this.heritageData.find(h => h.id === itemId);
+                if (item) {
+                    if (isKorean) {
+                        descriptionCell.textContent = item.content || '설명이 없습니다.';
+                    } else {
+                        descriptionCell.textContent = item.content_en || this.generateEnglishDescription(item);
+                    }
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Implement language toggle functionality for heritage details and lists to display `content_en` data.

The `updateDetailLanguage` and `updateListLanguage` methods in `data-manager.js` were previously empty, and `currentDetailItem` was not being set, preventing the language toggle from updating heritage descriptions on both detail and list pages. This PR addresses these issues by implementing the update logic and adding necessary data attributes and classes to rendered elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-d14aae2a-c025-4130-bc8b-6d059fba8c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d14aae2a-c025-4130-bc8b-6d059fba8c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

