### PR TITLE
Fix language toggle and add fallback

### DIFF
--- a/js/data-manager.js
+++ b/js/data-manager.js
@@ -1682,9 +1682,12 @@ class DataManager {
             // 한글 설명 표시
             descriptionElement.innerHTML = this.formatDescription(currentItem.content || '설명이 없습니다.');
         } else {
-            // 영어 설명 표시
-            const englishContent = currentItem.content_en || this.generateEnglishDescription(currentItem);
-            descriptionElement.innerHTML = this.formatDescription(englishContent);
+            // 영어 설명 표시 - content_en이 있으면 사용, 없으면 fallback 메시지 표시
+            if (currentItem.content_en && currentItem.content_en.trim() !== '') {
+                descriptionElement.innerHTML = this.formatDescription(currentItem.content_en);
+            } else {
+                descriptionElement.innerHTML = this.formatDescription('영문 설명을 준비 중입니다.');
+            }
         }
     }
     
@@ -1703,7 +1706,12 @@ class DataManager {
                     if (isKorean) {
                         descriptionElement.textContent = item.content || '설명이 없습니다.';
                     } else {
-                        descriptionElement.textContent = item.content_en || this.generateEnglishDescription(item);
+                        // 영어 설명 표시 - content_en이 있으면 사용, 없으면 fallback 메시지 표시
+                        if (item.content_en && item.content_en.trim() !== '') {
+                            descriptionElement.textContent = item.content_en;
+                        } else {
+                            descriptionElement.textContent = '영문 설명을 준비 중입니다.';
+                        }
                     }
                 }
             }
@@ -1720,7 +1728,12 @@ class DataManager {
                     if (isKorean) {
                         descriptionCell.textContent = item.content || '설명이 없습니다.';
                     } else {
-                        descriptionCell.textContent = item.content_en || this.generateEnglishDescription(item);
+                        // 영어 설명 표시 - content_en이 있으면 사용, 없으면 fallback 메시지 표시
+                        if (item.content_en && item.content_en.trim() !== '') {
+                            descriptionCell.textContent = item.content_en;
+                        } else {
+                            descriptionCell.textContent = '영문 설명을 준비 중입니다.';
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix language toggle to correctly display English descriptions from `item.content_en` and show a specific fallback message when `content_en` is empty or missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-7170092f-a54d-4579-a617-db408f189801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7170092f-a54d-4579-a617-db408f189801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

