### PR TITLE
Fix language selection and list update bugs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -419,7 +419,7 @@ function renderGridView(items) {
         const eraInfo = getEraInformation(item);
         return `
         <div class="heritage-grid-item">
-            <div class="card heritage-card h-100" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
+            <div class="card heritage-card h-100" data-item-id="${item.original_data?.composite_key || item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
                 <div class="card-img-top heritage-image">
                     ${item.image_url ? 
                         `<img src="${item.image_url}" alt="${item.name}" onerror="this.style.display='none'; this.parentElement.classList.add('no-image')">` : 
@@ -459,7 +459,7 @@ function renderListView(items) {
     tbody.innerHTML = items.map(item => {
         const eraInfo = getEraInformation(item);
         return `
-        <tr class="heritage-list-row" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
+        <tr class="heritage-list-row" data-item-id="${item.original_data?.composite_key || item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
             <td>
                 <div class="heritage-list-image">
                     ${item.image_url ? 
@@ -1149,7 +1149,7 @@ function renderCategoryGridView(items) {
         const eraInfo = getEraInformation(item);
         return `
         <div class="heritage-grid-item">
-            <div class="card heritage-card h-100" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
+            <div class="card heritage-card h-100" data-item-id="${item.original_data?.composite_key || item.id || item.name}" onclick="viewHeritageDetail('${item.name}')">
                 <div class="card-img-top heritage-image">
                     ${item.image_url ? 
                         `<img src="${item.image_url}" alt="${item.name}" onerror="this.style.display='none'; this.parentElement.classList.add('no-image')">` : 
@@ -1202,7 +1202,7 @@ function renderCategoryListView(items) {
     tbody.innerHTML = items.map(item => {
         const eraInfo = getEraInformation(item);
         return `
-        <tr class="heritage-list-row" data-item-id="${item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
+        <tr class="heritage-list-row" data-item-id="${item.original_data?.composite_key || item.id || item.name}" onclick="viewHeritageDetail('${item.name}')" style="cursor: pointer;">
             <td>
                 <div class="heritage-list-image">
                     ${item.image_url ? 


### PR DESCRIPTION
Update language display functions to use the passed `lang` parameter and correct item identification in list views.

Previously, language update functions ignored the explicitly passed language, and list items were not correctly identified due to using the wrong ID field (`id` instead of `composite_key`), leading to incorrect language display for details and lists. This PR ensures that the selected language is respected and items are correctly matched for updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c129cf5-0b7e-4e62-95cb-d34e5f0ce191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c129cf5-0b7e-4e62-95cb-d34e5f0ce191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

