### PR TITLE
Fix duplicate function overwriting language display

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -170,10 +170,10 @@ function setupEventListeners() {
                 window.dataManager.updateListLanguage(selectedLang);
             }
             
-            // 상세 페이지에서 언어 변경 시 설명 업데이트
-            if (window.dataManager && window.dataManager.currentDetailItem) {
-                updateHeritageDescription(window.dataManager.currentDetailItem);
-            }
+            // 상세 페이지에서 언어 변경 시 설명 업데이트 (dataManager가 이미 처리하므로 제거)
+            // if (window.dataManager && window.dataManager.currentDetailItem) {
+            //     updateHeritageDescription(window.dataManager.currentDetailItem);
+            // }
         });
     });
 }


### PR DESCRIPTION
Remove redundant `updateHeritageDescription` call to fix language toggle bug in detail view.

---
<a href="https://cursor.com/background-agent?bcId=bc-a40644c9-2242-43ca-9023-632b5a117647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a40644c9-2242-43ca-9023-632b5a117647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

