### PR TITLE
Fix duplicate constant declarations and undefined variables

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,12 +1,6 @@
 // 🚨 긴급 성능 복구 - 과도한 로깅 제거
-// 🔥 1단계: 로깅 레벨 조정 (모든 파일 상단에 추가)
-const DEBUG_MODE = false; // 🚨 false로 설정하여 로깅 비활성화
-
-function debugLog(...args) {
-    if (DEBUG_MODE) {
-        console.log(...args);
-    }
-}
+// 🔥 1단계: 로깅 레벨 조정 (중앙화된 설정 사용)
+// DEBUG_MODE와 debugLog는 config.js에서 가져옴
 
 /**
  * 메인 애플리케이션 - 뷰 컨트롤러 및 이벤트 핸들러

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,22 @@
+/**
+ * Application Configuration
+ * Centralized configuration for the heritage application
+ */
+
+// Debug mode configuration
+const DEBUG_MODE = false; // Set to true for development debugging
+
+/**
+ * Debug logging function
+ * Only logs when DEBUG_MODE is enabled
+ */
+function debugLog(...args) {
+    if (DEBUG_MODE) {
+        console.log(...args);
+    }
+}
+
+// Export for module systems (if needed)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { DEBUG_MODE, debugLog };
+}

--- a/js/data-manager.js
+++ b/js/data-manager.js
@@ -1,12 +1,6 @@
 // 🚨 긴급 성능 복구 - 과도한 로깅 제거
-// 🔥 1단계: 로깅 레벨 조정 (모든 파일 상단에 추가)
-const DEBUG_MODE = false; // 🚨 false로 설정하여 로깅 비활성화
-
-function debugLog(...args) {
-    if (DEBUG_MODE) {
-        console.log(...args);
-    }
-}
+// 🔥 1단계: 로깅 레벨 조정 (중앙화된 설정 사용)
+// DEBUG_MODE와 debugLog는 config.js에서 가져옴
 
 /**
  * 데이터 관리자 - CSV 로딩 및 데이터 처리 (성능 최적화)

--- a/js/router.js
+++ b/js/router.js
@@ -1,12 +1,6 @@
 // 🚨 긴급 성능 복구 - 과도한 로깅 제거
-// 🔥 1단계: 로깅 레벨 조정 (모든 파일 상단에 추가)
-const DEBUG_MODE = false; // 🚨 false로 설정하여 로깅 비활성화
-
-function debugLog(...args) {
-    if (DEBUG_MODE) {
-        console.log(...args);
-    }
-}
+// 🔥 1단계: 로깅 레벨 조정 (중앙화된 설정 사용)
+// DEBUG_MODE와 debugLog는 config.js에서 가져옴
 
 /**
  * SPA 라우터 - URL 해시 기반 페이지 라우팅

--- a/main.html
+++ b/main.html
@@ -775,6 +775,8 @@
     <!-- 문화재 데이터는 data-manager.js에서 자동 로드 -->
     
     <!-- 메인 앱 스크립트 -->
+    <!-- 중앙화된 설정 파일을 먼저 로드 -->
+    <script src="js/config.js"></script>
     <script src="js/indexeddb-manager.js"></script>
     <script src="js/i18n.js"></script>
     <script src="js/image-resolver.js"></script>


### PR DESCRIPTION
Centralize `DEBUG_MODE` and `debugLog` in `config.js` to resolve duplicate declaration errors and ensure proper script execution.

The `SyntaxError: Identifier 'DEBUG_MODE' has already been declared` was caused by `const DEBUG_MODE = false;` being present in `app.js`, `router.js`, and `data-manager.js`. This prevented `data-manager.js` from executing, leading to a subsequent `ReferenceError: dataManager is not defined` in `app.js`. This PR resolves both by creating a single source of truth for `DEBUG_MODE` and `debugLog` in `js/config.js` and ensuring it's loaded first.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1a4d7d2-05c0-4d87-8acd-2feec00b18cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1a4d7d2-05c0-4d87-8acd-2feec00b18cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

