### PR TITLE
Investigate and fix data loading failures

### DIFF
--- a/js/data-loader.js
+++ b/js/data-loader.js
@@ -99,7 +99,7 @@ class DataLoader {
             return null;
         }
 
-        const indexedData = await IndexedDBManager.getData('heritageData');
+        const indexedData = await window.indexedDBManager.loadData('heritageData');
         if (indexedData && indexedData.data) {
             return indexedData.data;
         }
@@ -137,7 +137,7 @@ class DataLoader {
     _backupToStorage(data, source) {
         // IndexedDB에 백업 (JavaScript에서 로드한 경우)
         if (source !== 'IndexedDB') {
-            IndexedDBManager.saveData('heritageData', { data, timestamp: Date.now() });
+            window.indexedDBManager.saveData(data, 'heritageData');
         }
         
         // LocalStorage에 백업 (작은 데이터만)

--- a/main.html
+++ b/main.html
@@ -762,7 +762,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
     
-    <!-- 문화재 데이터는 자동 로드됨 (45MB JSON 파일) -->
+    <!-- 문화재 데이터 파일 로드 -->
+    <script src="heritage-data-complete-20250922_153426.js"></script>
     
     <!-- 메인 앱 스크립트 -->
     <!-- 중앙화된 설정 파일을 먼저 로드 -->


### PR DESCRIPTION
Add data file to `main.html` and correct `IndexedDBManager` calls to resolve "Failed to load from all data sources" error.

The application was failing to load data because the `heritage-data-complete` file was not included in `main.html`, leading to an undefined `HERITAGE_DATA` variable. Additionally, `DataLoader` was calling incorrect methods on the `IndexedDBManager` instance (`getData` instead of `loadData`, and incorrect `saveData` arguments). These changes ensure the primary data source is loaded and backup mechanisms function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-b076f9b0-6123-4762-a96d-edf0001b756c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b076f9b0-6123-4762-a96d-edf0001b756c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

