### PR TITLE
Fix menu bar unclassified count id mismatch

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -500,15 +500,15 @@ function updateUnclassifiedStats() {
         // 안전한 속성 접근
         if (unclassifiedStats && typeof unclassifiedStats === 'object') {
             updateElement('unclassified-count', (unclassifiedStats.total || 0).toLocaleString());
-            updateElement('unclassified-sido-count', (unclassifiedStats.byType?.sidoType || 0).toLocaleString());
-            updateElement('unclassified-category-count', (unclassifiedStats.byType?.sidoFolklore || 0).toLocaleString());
+            updateElement('sido-type-count', (unclassifiedStats.byType?.sidoType || 0).toLocaleString());
+            updateElement('sido-folklore-count', (unclassifiedStats.byType?.sidoFolklore || 0).toLocaleString());
             updateElement('cultural-data-count', (unclassifiedStats.byType?.culturalData || 0).toLocaleString());
             updateElement('others-count', (unclassifiedStats.byType?.others || 0).toLocaleString());
         } else {
             // 기본값 설정
             updateElement('unclassified-count', '0');
-            updateElement('unclassified-sido-count', '0');
-            updateElement('unclassified-category-count', '0');
+            updateElement('sido-type-count', '0');
+            updateElement('sido-folklore-count', '0');
             updateElement('cultural-data-count', '0');
             updateElement('others-count', '0');
         }

--- a/js/app.js
+++ b/js/app.js
@@ -487,7 +487,6 @@ function updateTranslationRate() {
         
         // 번역률 표시 업데이트
         updateElement('translation-rate', `${rate.toFixed(1)}%`);
-        updateElement('translation-count', `${translationStats.translated.toLocaleString()}개`);
     }
 }
 
@@ -501,13 +500,17 @@ function updateUnclassifiedStats() {
         // 안전한 속성 접근
         if (unclassifiedStats && typeof unclassifiedStats === 'object') {
             updateElement('unclassified-count', (unclassifiedStats.total || 0).toLocaleString());
-            updateElement('unclassified-sido-count', (unclassifiedStats.sidoType || 0).toLocaleString());
-            updateElement('unclassified-category-count', (unclassifiedStats.categoryType || 0).toLocaleString());
+            updateElement('unclassified-sido-count', (unclassifiedStats.byType?.sidoType || 0).toLocaleString());
+            updateElement('unclassified-category-count', (unclassifiedStats.byType?.sidoFolklore || 0).toLocaleString());
+            updateElement('cultural-data-count', (unclassifiedStats.byType?.culturalData || 0).toLocaleString());
+            updateElement('others-count', (unclassifiedStats.byType?.others || 0).toLocaleString());
         } else {
             // 기본값 설정
             updateElement('unclassified-count', '0');
             updateElement('unclassified-sido-count', '0');
             updateElement('unclassified-category-count', '0');
+            updateElement('cultural-data-count', '0');
+            updateElement('others-count', '0');
         }
     }
 }

--- a/main.html
+++ b/main.html
@@ -98,11 +98,11 @@
                     <ul class="submenu">
                         <li><a href="#unclassified/sido-type" class="submenu-link">
                             <i class="fas fa-landmark"></i><span>시도유형문화재</span>
-                            <span class="badge bg-primary ms-2" id="sido-type-count">로딩 중...</span>
+                            <span class="badge bg-primary ms-2" id="unclassified-sido-count">로딩 중...</span>
                         </a></li>
                         <li><a href="#unclassified/sido-folklore" class="submenu-link">
                             <i class="fas fa-theater-masks"></i><span>시도민속문화재</span>
-                            <span class="badge bg-primary ms-2" id="sido-folklore-count">로딩 중...</span>
+                            <span class="badge bg-primary ms-2" id="unclassified-category-count">로딩 중...</span>
                         </a></li>
                         <li><a href="#unclassified/cultural-data" class="submenu-link">
                             <i class="fas fa-book"></i><span>문화재자료</span>

--- a/main.html
+++ b/main.html
@@ -98,11 +98,11 @@
                     <ul class="submenu">
                         <li><a href="#unclassified/sido-type" class="submenu-link">
                             <i class="fas fa-landmark"></i><span>시도유형문화재</span>
-                            <span class="badge bg-primary ms-2" id="unclassified-sido-count">로딩 중...</span>
+                            <span class="badge bg-primary ms-2" id="sido-type-count">로딩 중...</span>
                         </a></li>
                         <li><a href="#unclassified/sido-folklore" class="submenu-link">
                             <i class="fas fa-theater-masks"></i><span>시도민속문화재</span>
-                            <span class="badge bg-primary ms-2" id="unclassified-category-count">로딩 중...</span>
+                            <span class="badge bg-primary ms-2" id="sido-folklore-count">로딩 중...</span>
                         </a></li>
                         <li><a href="#unclassified/cultural-data" class="submenu-link">
                             <i class="fas fa-book"></i><span>문화재자료</span>


### PR DESCRIPTION
Align HTML IDs and JavaScript data access for unclassified item counts to ensure correct display in the menu bar, and remove an unused translation count.

The JavaScript function `updateUnclassifiedStats()` was attempting to update elements with IDs like `unclassified-sido-count` and `unclassified-category-count`, while the HTML used `sido-type-count` and `sido-folklore-count`. Furthermore, the data structure returned by `getUnclassifiedStats()` nested the counts under a `byType` property, which was not correctly accessed. This PR resolves these ID mismatches, corrects the data access path to `unclassifiedStats.byType.propertyName`, and ensures all unclassified categories are updated. It also removes a call to update `translation-count` as no corresponding HTML element exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-860e82cf-df5b-472f-b9c5-b201350353c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-860e82cf-df5b-472f-b9c5-b201350353c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

