### PR TITLE
Fix translation rate loading issue

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -485,8 +485,10 @@ function updateTranslationRate() {
         const translationStats = dataManager.getTranslationStats();
         const rate = translationStats.rate || 0;
         
-        // 번역률 표시 업데이트
+        // 두 곳 모두 업데이트
         updateElement('translation-rate', `${rate.toFixed(1)}%`);
+        updateElement('hero-translation-rate', `${rate.toFixed(1)}%`);
+        updateElement('translation-count', `${translationStats.translated.toLocaleString()}개`);
     }
 }
 

--- a/js/data-manager.js
+++ b/js/data-manager.js
@@ -306,15 +306,25 @@ class DataManager {
 
         // 번역률 계산
         const translatedCount = this.heritageData.filter(item => {
+            // english_description 또는 content_en 필드 중 하나라도 유효한 번역이 있으면 번역된 것으로 간주
             const englishDesc = item.english_description;
-            if (!englishDesc) return false;
+            const contentEn = item.content_en;
             
-            const descStr = String(englishDesc).trim();
-            return descStr !== '' && 
-                   descStr !== 'null' && 
-                   descStr !== 'undefined' &&
-                   descStr !== '영문 설명 준비 중입니다.' &&
-                   !descStr.includes('Description not available');
+            const hasValidEnglishDesc = englishDesc && 
+                String(englishDesc).trim() !== '' && 
+                String(englishDesc).trim() !== 'null' && 
+                String(englishDesc).trim() !== 'undefined' &&
+                String(englishDesc).trim() !== '영문 설명 준비 중입니다.' &&
+                !String(englishDesc).includes('Description not available');
+                
+            const hasValidContentEn = contentEn && 
+                String(contentEn).trim() !== '' && 
+                String(contentEn).trim() !== 'null' && 
+                String(contentEn).trim() !== 'undefined' &&
+                String(contentEn).trim() !== '영문 설명 준비 중입니다.' &&
+                !String(contentEn).includes('Description not available');
+            
+            return hasValidEnglishDesc || hasValidContentEn;
         }).length;
 
         stats.translationRate = this.heritageData.length > 0 ? Math.round((translatedCount / this.heritageData.length) * 100) : 0;


### PR DESCRIPTION
Update translation rate display in the hero section and improve translation rate calculation logic to include `content_en` field.

The hero section's translation rate was stuck on "로딩 중..." because its specific ID (`hero-translation-rate`) was not being updated by the JavaScript function. Additionally, the translation rate calculation was inaccurate as it only considered `english_description` and overlooked the `content_en` field, which also indicates translated content.

---
<a href="https://cursor.com/background-agent?bcId=bc-61565855-f1bd-4fd6-a52b-c9e4f2bf1857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61565855-f1bd-4fd6-a52b-c9e4f2bf1857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

