### PR TITLE
Add loadUnclassifiedView method to search-page.js

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -676,27 +676,30 @@ router.addRoute('unclassified', async (params) => {
     
     const unclassifiedType = params.type || 'sido-type';
     
+    // 데이터 매니저가 준비될 때까지 기다리기
+    await window.dataManager.waitForData();
+    
+    // 미분류 데이터 필터링
+    const unclassifiedData = window.dataManager.heritageData.filter(item => {
+        switch (unclassifiedType) {
+            case 'sido-type':
+                return item.kdcd_name === '시도유형문화재';
+            case 'sido-folklore':
+                return item.kdcd_name === '시도민속문화재';
+            case 'cultural-data':
+                return item.kdcd_name === '문화재자료';
+            case 'others':
+                return item.kdcd_name === '미분류' || item.ctcd_name === '미분류';
+            default:
+                return false;
+        }
+    });
+    
+    console.log('🔄 미분류 데이터 필터링 완료:', unclassifiedData.length, '건');
+    
     if (window.searchPage && typeof window.searchPage.loadUnclassifiedView === 'function') {
-        await window.searchPage.loadUnclassifiedView(unclassifiedType);
+        await window.searchPage.loadUnclassifiedView(unclassifiedType, unclassifiedData, 1);
     } else {
         console.error('❌ searchPage 또는 loadUnclassifiedView 함수를 찾을 수 없습니다');
-        // 🚀 대체 로직: 직접 미분류 데이터 필터링
-        if (window.dataManager && window.dataManager.heritageData) {
-            const unclassifiedData = window.dataManager.heritageData.filter(item => {
-                switch (unclassifiedType) {
-                    case 'sido-type':
-                        return item.kdcd_name === '시도유형문화재';
-                    case 'sido-folklore':
-                        return item.kdcd_name === '시도민속문화재';
-                    case 'cultural-data':
-                        return item.kdcd_name === '문화재자료';
-                    case 'others':
-                        return item.kdcd_name === '미분류' || item.ctcd_name === '미분류';
-                    default:
-                        return false;
-                }
-            });
-            console.log('🔄 미분류 데이터 필터링 실행:', unclassifiedData.length, '건');
-        }
     }
 });

--- a/js/search-page.js
+++ b/js/search-page.js
@@ -84,6 +84,40 @@ class SearchPage {
     }
 
     /**
+     * 미분류 항목 표시 (라우터에서 호출)
+     */
+    async loadUnclassifiedView(type, data, page = 1) {
+        console.log(`미분류 뷰 로드: ${type}, ${data.length}건, 페이지 ${page}`);
+        
+        this.currentPage = page;
+        this.currentQuery = type; // 타입을 쿼리로 저장
+        
+        // 데이터가 없으면 빈 결과 표시
+        if (!data || data.length === 0) {
+            this.renderSearchResults([]);
+            this.renderSearchPagination(1, 1, 0);
+            return;
+        }
+        
+        // 페이지네이션 처리
+        const paginationData = this.getPaginatedData(data, page);
+        
+        if (!paginationData) {
+            console.warn('페이지네이션 데이터 없음');
+            this.renderSearchResults([]);
+            return;
+        }
+        
+        console.log(`✅ 미분류 항목 표시: ${paginationData.items.length}개 (${paginationData.currentPage}/${paginationData.totalPages})`);
+        
+        // 결과 렌더링 (검색 결과와 동일한 방식)
+        this.renderSearchResults(paginationData.items);
+        
+        // 페이지네이션 렌더링
+        this.renderSearchPagination(paginationData.currentPage, paginationData.totalPages, paginationData.totalItems);
+    }
+
+    /**
      * 페이지네이션 데이터 생성
      */
     getPaginatedData(data, page) {


### PR DESCRIPTION
Add `loadUnclassifiedView` to `SearchPage` and update `router.js` to correctly display unclassified heritage items.

The `router.js` was calling `searchPage.loadUnclassifiedView` for unclassified categories, but this method was missing in `search-page.js`. This led to a blank page when clicking on unclassified items, as data was filtered but never rendered. This PR resolves the issue by implementing the missing method and ensuring data is passed correctly for display.

---
<a href="https://cursor.com/background-agent?bcId=bc-fae1bc42-6309-4ab8-9c81-515f12dd6b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fae1bc42-6309-4ab8-9c81-515f12dd6b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

